### PR TITLE
chore: add issue templates, CONTRIBUTING and QUICKSTART

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Reportar um problema no pipeline ou scripts
+labels: bug
+---
+
+Descrição
+
+Passos para reproduzir
+1.
+2.
+3.
+
+Comportamento esperado
+
+Logs/Saída relevante
+
+Ambiente
+- SO/versão:
+- Versões: `vina`, `obabel`, `python3`, MGLTools
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions / Help
+    url: https://github.com/LuizRMSilva1973/vassouradebruxa/discussions
+    about: Perguntas gerais e suporte de uso
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Propor melhoria ou nova funcionalidade
+labels: enhancement
+---
+
+Resumo da proposta
+
+Detalhes / escopo
+
+Critérios de aceite
+- [ ]
+- [ ]
+
+Considerações técnicas
+

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,14 @@
+---
+name: Task / Checklist
+about: Item de trabalho com checklist
+labels: task
+---
+
+Objetivo
+
+Checklist
+- [ ]
+- [ ]
+
+Notas adicionais
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+## Contribuindo
+
+Obrigado por contribuir! Siga estas orientações rápidas:
+
+- Abra uma issue descrevendo o objetivo antes de um PR significativo.
+- Use branches descritivas (ex.: `feat/…`, `fix/…`, `docs/…`, `chore/…`).
+- Siga o estilo dos scripts existentes; mantenha mudanças focadas.
+- Evite commitar arquivos grandes/resultados (veja `.gitignore`).
+
+### Fluxo sugerido
+1. Fork/branch a partir de `main`.
+2. Implementa e testa localmente: `./run_docking.sh` e `python3 topn_by_target.py`.
+3. Atualize docs se necessário (`README.md`, `QUICKSTART.md`).
+4. Abra PR vinculando à issue e descrevendo mudanças/impacto.
+
+### Qualidade
+- Shell: prefira `bash`, `set -euo pipefail`, mensagens claras.
+- Python: use `argparse`, mensagens de erro úteis e CSVs consistentes.
+

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,34 @@
+# Quickstart
+
+1) Pré-requisitos
+- AutoDock Vina (`vina`), OpenBabel (`obabel`), MGLTools (pythonsh + Utilities24).
+
+2) Estrutura mínima
+```
+./
+  targets/
+    CHS.pdb
+    CHS.box   # center_*, size_* (ver README)
+  ligands/
+    nikkomicinaZ.sdf
+    polioxinaD.sdf
+```
+
+3) Rodar docking
+```
+chmod +x run_docking.sh
+./run_docking.sh -e 16 -n 9
+```
+Saída: `docking_results/summary_affinities.csv` e subpastas por (alvo x ligante).
+
+4) Top-N por alvo
+```
+python3 topn_by_target.py --input docking_results/summary_affinities.csv \
+  --outdir docking_results/topN_by_target --top 10
+```
+
+5) Próximos passos
+- Adicionar mais alvos e caixas (`targets/*.box`).
+- Popular mais ligantes em `ligands/`.
+- Refinar parâmetros (`--exhaustiveness`, `--num-modes`).
+


### PR DESCRIPTION
This PR adds:

- GitHub issue templates (bug, feature, task) and config
- CONTRIBUTING.md with basic workflow
- QUICKSTART.md for minimal run instructions

Rationale: standardize collaboration and make it easy to onboard and track next steps.